### PR TITLE
FUT1-23535

### DIFF
--- a/hapi-fhir-bom/pom.xml
+++ b/hapi-fhir-bom/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>ca.uhn.hapi.fhir</groupId>
 	<artifactId>hapi-fhir-bom</artifactId>
-	<version>8.6.5-sse1</version>
+	<version>8.6.5-sse2</version>
 
 	<packaging>pom</packaging>
 	<name>HAPI FHIR BOM</name>
@@ -18,7 +18,7 @@
 	</parent>
 	<properties>
 		<hapifhir.version>8.6.5</hapifhir.version>
-		<sse.version>sse1</sse.version>
+		<sse.version>sse2</sse.version>
 	</properties>
 
 	<dependencyManagement>

--- a/hapi-fhir-serviceloaders/pom.xml
+++ b/hapi-fhir-serviceloaders/pom.xml
@@ -11,7 +11,7 @@
 
 	<artifactId>hapi-fhir-serviceloaders</artifactId>
 	<packaging>pom</packaging>
-	<version>8.6.5-sse1</version>
+	<version>8.6.5-sse2</version>
 
 	<name>HAPI FHIR - ServiceLoaders</name>
 	

--- a/hapi-fhir-validation-resources-r4/src/main/resources/org/hl7/fhir/r4/model/profile/profiles-resources.xml
+++ b/hapi-fhir-validation-resources-r4/src/main/resources/org/hl7/fhir/r4/model/profile/profiles-resources.xml
@@ -285684,7 +285684,7 @@
        <key value="que-7"></key>
        <severity value="error"></severity>
        <human value="If the operator is 'exists', the value must be a boolean"></human>
-       <expression value="operator = 'exists' implies (answer is Boolean)"></expression>
+       <expression value="operator = 'exists' implies (answer is boolean)"></expression>
        <xpath value="f:operator/@value != 'exists' or exists(f:answerBoolean)"></xpath>
       </constraint>
       <isModifier value="true"></isModifier>
@@ -287384,7 +287384,7 @@
        <key value="que-7"></key>
        <severity value="error"></severity>
        <human value="If the operator is 'exists', the value must be a boolean"></human>
-       <expression value="operator = 'exists' implies (answer is Boolean)"></expression>
+       <expression value="operator = 'exists' implies (answer is boolean)"></expression>
        <xpath value="f:operator/@value != 'exists' or exists(f:answerBoolean)"></xpath>
       </constraint>
       <isModifier value="true"></isModifier>

--- a/hapi-fhir-validation/src/test/java/org/hl7/fhir/r4/validation/QuestionnaireValidatorR4Test.java
+++ b/hapi-fhir-validation/src/test/java/org/hl7/fhir/r4/validation/QuestionnaireValidatorR4Test.java
@@ -103,6 +103,35 @@ public class QuestionnaireValidatorR4Test extends BaseValidationTestWithInlineMo
 		}
 	}
 
+	/**
+	 * FUT1-23535: Regression test for que-7 on Questionnaire.item.enableWhen.
+	 *
+	 * The base R4 constraint expression as published is {@code operator = 'exists' implies (answer is Boolean)}.
+	 * The core FHIRPath engine compares the FHIR primitive type name {@code boolean} (lowercase) against the
+	 * literal {@code Boolean} (capitalised) with case-sensitive {@code .equals}, so every Questionnaire that uses
+	 * {@code operator: "exists"} with {@code answerBoolean: true} fails que-7. The fix lowercases {@code Boolean}
+	 * to {@code boolean} in profiles-resources.xml so the type name matches.
+	 */
+	@Test
+	public void testQuestionnaire_enableWhenExistsWithAnswerBoolean_passesQue7() {
+		String json = "{ \"resourceType\": \"Questionnaire\", \"status\": \"draft\", \"item\": [" +
+			"{ \"linkId\": \"q1\", \"type\": \"boolean\", \"text\": \"q1\", \"required\": false }," +
+			"{ \"linkId\": \"q2\", \"type\": \"choice\", \"text\": \"q2\", \"required\": false," +
+			"  \"enableWhen\": [ { \"question\": \"q1\", \"operator\": \"exists\", \"answerBoolean\": true } ]," +
+			"  \"answerOption\": [ { \"valueString\": \"A\" } ] } ] }";
+
+		Questionnaire q = ourCtx.newJsonParser().parseResource(Questionnaire.class, json);
+		ValidationResult errors = myVal.validateWithResult(q);
+
+		ourLog.info(errors.toString());
+		assertThat(errors.getMessages().stream()
+			.filter(t -> t.getSeverity().ordinal() >= ResultSeverityEnum.ERROR.ordinal())
+			.filter(t -> t.getMessage().contains("que-7"))
+			.collect(Collectors.toList()))
+			.as("que-7 must not fire for operator=exists with answerBoolean=true")
+			.isEmpty();
+	}
+
 	@Test
 	public void testQuestionnaireWithCustomExtensionDomain() {
 		String extensionUrl = "http://my.own.domain/StructureDefinition/";


### PR DESCRIPTION
Fix que-7 false positive on Questionnaire.item.enableWhen The published R4 expression `answer is Boolean` is case-sensitive and never matches the FHIR primitive `boolean`, so every enableWhen with operator=exists fails validation. Lowercase the type name to `boolean`.